### PR TITLE
Fixes wave import error.

### DIFF
--- a/wavebender/__init__.py
+++ b/wavebender/__init__.py
@@ -7,7 +7,7 @@ Good luck! (This is a work in progress.)
 """
 import sys
 import math
-import wave
+from . import wave
 import struct
 import random
 import argparse


### PR DESCRIPTION
Python 3.4.5 used the builtin wave.py rather than the patched version. This PR fixes that. This may fix #5 again.